### PR TITLE
Adding a code generator to modify DaoFactory

### DIFF
--- a/Resources/config/container/tdbm.xml
+++ b/Resources/config/container/tdbm.xml
@@ -12,6 +12,9 @@
         <service id="TheCodingMachine\TDBM\Configuration" class="TheCodingMachine\TDBM\Configuration">
             <argument></argument> <!-- will be filled in with tdbm.bean_namespace dynamically -->
             <argument></argument> <!-- will be filled in with tdbm.dao_namespace dynamically -->
+            <argument key="$codeGeneratorListeners" type="collection">
+                <argument type="service" id="TheCodingMachine\TDBM\Bundle\Utils\SymfonyCodeGeneratorListener"/>
+            </argument>
         </service>
 
         <service id="TheCodingMachine\TDBM\ConfigurationInterface" alias="TheCodingMachine\TDBM\Configuration">
@@ -40,6 +43,8 @@
         <service id="tdbm.SchemaManager" class="Doctrine\DBAL\Schema\AbstractSchemaManager">
             <factory service="doctrine.dbal.default_connection" method="getSchemaManager" />
         </service>
+
+        <service id="TheCodingMachine\TDBM\Bundle\Utils\SymfonyCodeGeneratorListener" />
     </services>
 
 </container>

--- a/Tests/Utils/SymfonyCodeGeneratorListenerTest.php
+++ b/Tests/Utils/SymfonyCodeGeneratorListenerTest.php
@@ -27,7 +27,6 @@ class SymfonyCodeGeneratorListenerTest extends TestCase
 
         $file = $codeGeneratorListener->onDaoFactoryGenerated($file, [$beanDescriptor], $configuration);
 
-        var_dump($file->getClass()->getImplementedInterfaces());
         $this->assertContains(ServiceSubscriberInterface::class, $file->getClass()->getImplementedInterfaces());
         $this->assertContains(<<<CODE
 return [

--- a/Tests/Utils/SymfonyCodeGeneratorListenerTest.php
+++ b/Tests/Utils/SymfonyCodeGeneratorListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TheCodingMachine\TDBM\Bundle\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use TheCodingMachine\TDBM\Configuration;
+use TheCodingMachine\TDBM\Utils\BeanDescriptor;
+use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\FileGenerator;
+
+class SymfonyCodeGeneratorListenerTest extends TestCase
+{
+
+    public function testOnDaoFactoryGenerated()
+    {
+        $file = new FileGenerator();
+        $class = new ClassGenerator("Foo");
+        $file->setClass($class);
+
+        $codeGeneratorListener = new SymfonyCodeGeneratorListener();
+
+        $beanDescriptor = $this->createMock(BeanDescriptor::class);
+        $beanDescriptor->method('getDaoClassName')->willReturn('FooDao');
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getDaoNamespace')->willReturn('App\\Dao');
+
+        $file = $codeGeneratorListener->onDaoFactoryGenerated($file, [$beanDescriptor], $configuration);
+
+        var_dump($file->getClass()->getImplementedInterfaces());
+        $this->assertContains(ServiceSubscriberInterface::class, $file->getClass()->getImplementedInterfaces());
+        $this->assertContains(<<<CODE
+return [
+    'App\\\\Dao\\\\FooDao' => 'App\\\\Dao\\\\FooDao',
+];
+CODE
+            , $file->getClass()->getMethod('getSubscribedServices')->getBody());
+    }
+}

--- a/Utils/SymfonyCodeGeneratorListener.php
+++ b/Utils/SymfonyCodeGeneratorListener.php
@@ -8,6 +8,8 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use TheCodingMachine\TDBM\ConfigurationInterface;
 use TheCodingMachine\TDBM\Utils\BaseCodeGeneratorListener;
 use TheCodingMachine\TDBM\Utils\BeanDescriptor;
+use Zend\Code\Generator\DocBlock\Tag\ReturnTag;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\FileGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use function var_export;
@@ -36,7 +38,14 @@ class SymfonyCodeGeneratorListener extends BaseCodeGeneratorListener
             $getterBody
         );
         $method->setStatic(true);
-        $method->setReturnType('void');
+        $method->setDocBlock(new DocBlockGenerator(
+            null,
+            null,
+            [
+                new ReturnTag([ 'array<string,string>' ])
+            ]
+        ));
+        $method->setReturnType('array');
         $class->addMethodFromGenerator($method);
 
         return $fileGenerator;

--- a/Utils/SymfonyCodeGeneratorListener.php
+++ b/Utils/SymfonyCodeGeneratorListener.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM\Bundle\Utils;
+
+
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use TheCodingMachine\TDBM\ConfigurationInterface;
+use TheCodingMachine\TDBM\Utils\BaseCodeGeneratorListener;
+use TheCodingMachine\TDBM\Utils\BeanDescriptor;
+use Zend\Code\Generator\FileGenerator;
+use Zend\Code\Generator\MethodGenerator;
+use function var_export;
+
+class SymfonyCodeGeneratorListener extends BaseCodeGeneratorListener
+{
+    /**
+     * @param BeanDescriptor[] $beanDescriptors
+     */
+    public function onDaoFactoryGenerated(FileGenerator $fileGenerator, array $beanDescriptors, ConfigurationInterface $configuration): ?FileGenerator
+    {
+        $class = $fileGenerator->getClass();
+        $class->setImplementedInterfaces([ ServiceSubscriberInterface::class ]);
+
+        $getterBody = "return [\n";
+        foreach ($beanDescriptors as $beanDescriptor) {
+            $varExportClassName = var_export($configuration->getDaoNamespace().'\\'.$beanDescriptor->getDaoClassName(), true);
+            $getterBody .= "    $varExportClassName => $varExportClassName,\n";
+        }
+        $getterBody .= "];\n";
+
+        $method = new MethodGenerator(
+            'getSubscribedServices',
+            [],
+            MethodGenerator::FLAG_PUBLIC,
+            $getterBody
+        );
+        $method->setStatic(true);
+        $method->setReturnType('void');
+        $class->addMethodFromGenerator($method);
+
+        return $fileGenerator;
+    }
+}


### PR DESCRIPTION
The code generator adds the ServiceSubscriberInterface dynamically to DaoFactory.
Therefore, the DaoFactory can now be fed with the ContainerInterface, fetch the DAOs while keeping the DAOs private.
Closes https://github.com/thecodingmachine/tdbm/issues/115